### PR TITLE
Bump to 0.1.4 - Leptos Wasi now Compatible to latest leptos 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,22 +8,23 @@ version = "0.1.3"
 edition = "2021"
 
 [dependencies]
-throw_error = { version = "0.2.0" }
-hydration_context = { version = "0.2.0" }
+throw_error = { version = "0.3.0" }
+hydration_context = { version = "0.3.0" }
 futures = "0.3.30"
-wasi = "0.13.1+wasi-0.2.0"
-leptos = { version = "0.7.0",  features = ["nonce", "ssr"] }
-leptos_meta = { version = "0.7.0",  features = ["ssr"] }
-leptos_router ={ version = "0.7.0",  features = ["ssr"] }
-leptos_macro ={ version = "0.7.0",  features = ["generic"] }
-leptos_integration_utils = { version = "0.7.0" }
-server_fn = { version = "0.7.0",  features = ["generic"] }
-http = "1.1.0"
-parking_lot = "0.12.3"
-bytes = "1.7.2"
+wasi = "0.14.7+wasi-0.2.4"
+leptos = { version = "0.8.9",  features = ["nonce", "ssr"] }
+leptos_meta = { version = "0.8.5",  features = ["ssr"] }
+leptos_router ={ version = "0.8.7",  features = ["ssr"] }
+leptos_macro ={ version = "0.8.8",  features = ["generic"] }
+leptos_integration_utils = { version = "0.8.5" }
+server_fn = { version = "0.8.7",  features = ["generic"] }
+http = "1.3.1"
+parking_lot = "0.12.4"
+bytes = "1.10.1"
 routefinder = "0.5.4"
-mime_guess = "2.0"
-thiserror = "2"
+mime_guess = "2.0.5"
+thiserror = "2.0.16"
+any_spawner = { version = "0.3.0", features = ["async-executor", "futures-executor"] }
 
 [features]
 islands-router = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "leptos_wasi"
-authors = ["Enzo Nocera"]
+authors = ["Enzo Nocera" , "Uriah Galang"]
 license = "MIT"
 repository = "https://github.com/leptos-rs/leptos_wasi"
 description = "WASI integrations for the Leptos web framework."
-version = "0.1.3"
-edition = "2021"
+version = "0.1.4"
+edition = "2024"
 
 [dependencies]
 throw_error = { version = "0.3.0" }
 hydration_context = { version = "0.3.0" }
-futures = "0.3.30"
+futures = "0.3.31"
 wasi = "0.14.7+wasi-0.2.4"
 leptos = { version = "0.8.9",  features = ["nonce", "ssr"] }
 leptos_meta = { version = "0.8.5",  features = ["ssr"] }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,7 +2,7 @@
 # to follow the same conventions across the organisation.
 
 # Stable options
-edition = "2021"
+edition = "2024"
 max_width = 80
 
 # Unstable options

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -26,7 +26,6 @@ use futures::{
     task::{LocalSpawnExt, SpawnExt},
     FutureExt, Stream,
 };
-use leptos::task::{any_spawner, CustomExecutor};
 use parking_lot::Mutex;
 use std::{
     cell::RefCell,
@@ -40,6 +39,8 @@ use wasi::{
     clocks::monotonic_clock::{subscribe_duration, Duration},
     io::poll::{poll, Pollable},
 };
+
+use any_spawner::{CustomExecutor, PinnedFuture, PinnedLocalFuture};
 
 struct TableEntry(Pollable, Waker);
 
@@ -208,11 +209,11 @@ impl Executor {
 }
 
 impl CustomExecutor for Executor {
-    fn spawn(&self, fut: any_spawner::PinnedFuture<()>) {
+    fn spawn(&self, fut: PinnedFuture<()>) {
         self.0.spawner.spawn(fut).unwrap();
     }
 
-    fn spawn_local(&self, fut: any_spawner::PinnedLocalFuture<()>) {
+    fn spawn_local(&self, fut: PinnedLocalFuture<()>) {
         self.0.spawner.spawn_local(fut).unwrap();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! that you can leverage to use this crate.
 //!
 //! ```
-//! use leptos::task::Executor;
+//! use any_spawner::Executor;
 //! use leptos_wasi::prelude::WasiExecutor;
 //! use wasi::exports::http::incoming_handler::*;
 //!
@@ -50,6 +50,7 @@ pub mod prelude {
         executor::Executor as WasiExecutor, handler::Handler, response::Body,
         utils::redirect,
     };
+    pub use any_spawner::Executor;
     pub use http::StatusCode;
     pub use wasi::exports::wasi::http::incoming_handler::{
         IncomingRequest, ResponseOutparam,


### PR DESCRIPTION
## Update to server_fn 0.8.7 and leptos_integration_utils 0.8.5

### Changes Made:

**Migration to Updated Dependencies:**
- Updated codebase to be compatible with breaking changes in server_fn 0.8.7 and leptos_integration_utils 0.8.5

**Key Modifications:**

1. **ServerFn Trait Updates (`src/handler.rs`):**
   - Refactored `with_server_fn` method to handle new ServerFn trait structure
   - ServerFn no longer has `ServerRequest`/`ServerResponse` associated types
   - Updated to use `Protocol` associated type for method determination
   - `ServerFnTraitObj::new()` signature changed from 4 parameters to 1

2. **SSR Mode Handler Updates:**
   - Added third boolean parameter (`_islands_nav`) to all SSR mode closures (Async, InOrder, PartiallyBlocked/OutOfOrder)
   - Added 6th boolean parameter to `Response::from_app()` for out-of-order streaming support

3. **Middleware Updates:**
   - Modified `sfn.run()` to include error serialization function returning `Bytes`

4. **Import Updates (`src/lib.rs`):**
   - Migrated from `leptos::task::Executor` to `any_spawner::Executor`
   - Updated prelude exports to include the new Executor

5. **Documentation:**
   - Added comprehensive migration diagnostic comments documenting all API changes for future reference

### Impact:
- Ensures compatibility with latest versions of core dependencies
- Maintains existing functionality while adapting to new API requirements
- No breaking changes to the public API of leptos_wasi

This update is necessary to stay current with the evolving Leptos ecosystem and maintain compatibility with newer versions of dependencies.