### PR TITLE
added feature flag for spin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ leptos_meta = { version = "0.8.5",  features = ["ssr"] }
 leptos_router ={ version = "0.8.7",  features = ["ssr"] }
 leptos_macro ={ version = "0.8.8",  features = ["generic"] }
 leptos_integration_utils = { version = "0.8.5" }
-server_fn = { version = "0.8.7",  features = ["generic"] }
+server_fn = { version = "0.8.7" }
 http = "1.3.1"
 parking_lot = "0.12.4"
 bytes = "1.10.1"
@@ -27,4 +27,7 @@ thiserror = "2.0.16"
 any_spawner = { version = "0.3.0", features = ["async-executor", "futures-executor"] }
 
 [features]
+default = ["generic"]
 islands-router = []
+spin = ["server_fn/axum-no-default"]
+generic = ["server_fn/generic", "server_fn/ssr"]

--- a/README.md
+++ b/README.md
@@ -50,11 +50,69 @@ Contributions are welcome!
 
 ## Usage
 
-TODO: Write a template starter for the crate.
+### Installation
+
+Add `leptos_wasi` to your `Cargo.toml` dependencies. The crate supports two modes depending on your deployment target:
+
+#### For Standard Leptos Projects
+
+For standard Leptos server-side applications (non-Spin), use the default features:
+
+```toml
+[dependencies]
+leptos_wasi = { version = "0.1.4" }
+# or explicitly:
+leptos_wasi = { version = "0.1.4", features = ["generic"] }
+```
+
+#### For Spin WebAssembly Projects
+
+For projects targeting the [Spin](https://www.fermyon.com/spin) WebAssembly runtime:
+
+```toml
+[dependencies]
+leptos_wasi = { version = "0.1.4", default-features = false, features = ["spin"] }
+```
+
+### Feature Flags
+
+- **`generic`** (default): Enables support for standard Leptos server-side applications with full generic body types
+- **`spin`**: Enables support for Spin WebAssembly runtime with simplified body types (`Bytes`)
+- **`islands-router`**: Enables islands architecture support for partial hydration
+
+### Example Usage
+
+```rust
+use leptos_wasi::Handler;
+
+// Your Leptos app component
+#[component]
+fn App() -> impl IntoView {
+    // Your app implementation
+}
+
+// In your WASI entry point
+#[export_name = "wasi:http/incoming-handler@0.2.0#handle"]
+pub unsafe extern "C" fn handle(request: IncomingRequest, response_outparam: ResponseOutparam) {
+    let handler = Handler::build(request, response_outparam)
+        .expect("Failed to build handler");
+    
+    // For Spin projects with server functions
+    #[cfg(feature = "spin")]
+    let handler = handler.with_server_fn::<YourServerFn>();
+    
+    // Generate routes and handle the request
+    handler
+        .generate_routes(App)
+        .handle_with_context(App, || {})
+        .await
+        .expect("Failed to handle request");
+}
+```
 
 ### Compatibility
 
-This crate only works with the future **Leptos v0.7**.
+This crate works with Leptos v0.8+ and supports both standard server deployments and WebAssembly Component Model deployments.
 
 ## Features
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -3,7 +3,11 @@ use futures::{Stream, StreamExt};
 use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use leptos_integration_utils::ExtendResponse;
 use parking_lot::RwLock;
+#[cfg(feature = "generic")]
 use server_fn::response::generic::Body as ServerFnBody;
+
+#[cfg(not(feature = "generic"))]
+use bytes::Bytes as ServerFnBody;
 use std::{pin::Pin, sync::Arc};
 use thiserror::Error;
 use wasi::http::types::{HeaderError, Headers};
@@ -55,12 +59,20 @@ pub enum Body {
     ),
 }
 
+#[cfg(feature = "generic")]
 impl From<ServerFnBody> for Body {
     fn from(value: ServerFnBody) -> Self {
         match value {
             ServerFnBody::Sync(data) => Self::Sync(data),
             ServerFnBody::Async(stream) => Self::Async(stream),
         }
+    }
+}
+
+#[cfg(not(feature = "generic"))]
+impl From<ServerFnBody> for Body {
+    fn from(value: ServerFnBody) -> Self {
+        Self::Sync(value)
     }
 }
 


### PR DESCRIPTION
## PR Summary: Add dual-mode support for Spin and Standard Leptos projects

### Problem Solved
The leptos_wasi fork previously couldn't support both Spin WebAssembly projects and standard Leptos projects simultaneously due to incompatible type requirements:
- Spin projects require simplified `Bytes` types and `axum-no-default` feature
- Standard projects require generic `Body` types and `generic` feature from server_fn

### Changes Made

#### 1. **Feature Flag Strategy** (`Cargo.toml`)
- Added `spin` feature flag: enables `server_fn/axum-no-default` for Spin compatibility
- Added `generic` feature flag (default): enables `server_fn/generic` and `server_fn/ssr` for standard projects
- Removed hardcoded features from server_fn dependency to allow flexible configuration

#### 2. **Conditional Compilation** (`src/handler.rs`, `src/response.rs`)
- Implemented conditional imports using `#[cfg(feature = "...")]` attributes
- Generic mode: uses `server_fn::response::generic::Body` and `server_fn::http_export`
- Spin mode: uses `server_fn::Bytes` and `server_fn::http` directly
- Added separate implementations of `with_server_fn()` for each mode

#### 3. **Documentation Updates** (`README.md`)
- Added installation instructions for both project types
- Documented available feature flags (`generic`, `spin`, `islands-router`)
- Provided usage examples showing how to configure dependencies correctly

### Usage

**For Spin projects:**
```toml
leptos_wasi = { version = "0.1.4", default-features = false, features = ["spin"] }
```

**For standard Leptos projects:**
```toml
leptos_wasi = { version = "0.1.4" } # Uses default "generic" feature
```


### Breaking Changes
None - existing projects using default features continue to work as before.